### PR TITLE
fix incorrect test in goWindowCloseCB()

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -35,7 +35,7 @@ var windowClose WindowCloseHandler
 
 //export goWindowCloseCB
 func goWindowCloseCB() C.int {
-	if goWindowCloseCB == nil {
+	if windowClose == nil {
 		return 0
 	}
 	return C.int(windowClose())


### PR DESCRIPTION
While windowClose supposed to be one of the first functions a user of the library shall define, it would be nice to handle if it is not unset.

Warning: This code is untested, but it builds. I just noticed this bug when looking at the source the very first time. I had no time yet to install all dependencies to test it.

Additional suggestion: mention "brew install glfw" as an easy way to install the libglfw dependency easily on Mac OS X with Homebrew (at the time of this writing it installs 2.7.5 instead of 2.7.6 which is the newest).
