### PR TITLE
Changed argument name for MouseWheelHandler

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -113,14 +113,14 @@ func SetMousePosCallback(f MousePosHandler) {
 
 // =============================================================================
 
-type MouseWheelHandler func(delta int)
+type MouseWheelHandler func(pos int)
 
 var mouseWheel []MouseWheelHandler
 
 //export goMouseWheelCB
-func goMouseWheelCB(delta C.int) {
+func goMouseWheelCB(pos C.int) {
 	for _, f := range mouseWheel {
-		f(int(delta))
+		f(int(pos))
 	}
 }
 


### PR DESCRIPTION
Changed from "delta" to "pos" since the value reported by GLFW is not a delta, but rather a tracked position, and the distinction in godoc caused some confusion. See the reference manual for confirmation, section 3.4.13.

```
void GLFWCALL functionname( int pos );
```
